### PR TITLE
Add groupName and groupPassword arguments to CodingDojo.new

### DIFF
--- a/Classes/CodingDojo.sc
+++ b/Classes/CodingDojo.sc
@@ -1,19 +1,21 @@
 CodingDojo {
-	var <username, <password, <serveraddress, <serverport;
+	var <username, <password, <serveraddress, <serverport, <groupName, <groupPassword;
 	var <oscrouter, <syncText;
 	var <>turnTime = 300, <remainTime, <timer;
 	var <pilot, <copilot, <nextCopilot, <myStatus, <order;
 	var <win, <uv;
 
-	*new { arg username, password, serveraddress = "bgo.la", serverport = 55555;
-		^super.newCopyArgs(username.asSymbol, password.asSymbol, serveraddress.asString, serverport).init;
+	*new { arg username, password, serveraddress = "bgo.la", serverport = 55555,
+		groupName, groupPassword;
+		^super.newCopyArgs(username.asSymbol, password.asSymbol, serveraddress.asString, serverport, groupName, groupPassword).init;
 	}
 
 	init {
 		this.initTimer;
 		this.initRoles;
 
-		oscrouter = OSCRouterClient(serveraddress, username, password, serverport: serverport);
+		oscrouter = OSCRouterClient(serveraddress, username, password,
+			groupName: groupName, groupPassword: groupPassword, serverport: serverport);
 		oscrouter.join({ this.initOnJoined });
 	}
 
@@ -39,6 +41,8 @@ CodingDojo {
 		syncText.showDoc;
 		this.addOSCFuncs;
 		this.enableCodeSending;
+		groupName = oscrouter.groupName;
+		groupPassword = oscrouter.groupPassword
 	}
 
 	setupUserView {

--- a/Classes/OSCRouterClient.sc
+++ b/Classes/OSCRouterClient.sc
@@ -27,9 +27,12 @@ OSCRouterClient {
 	// if there is already a client with these specs,
 	// use that to avoid doubled login failure and confusion.
 	*new { arg serverAddr, userName, userPassword, onJoined,
-		groupName = 'oscrouter', groupPassword = 'oscrouter', serverport = 55555;
+		groupName, groupPassword, serverport = 55555;
 
-		var found = this.findBy(userName, groupName, serverAddr, serverport);
+		var found;
+		groupName = groupName ? 'oscrouter';
+		groupPassword = groupPassword ? 'oscrouter';
+		found = this.findBy(userName, groupName, serverAddr, serverport);
 
 		case { found.size > 1 } {
 			"*** OSCRouterClient:new - multiple matching clients found, please be more specific!".postln;

--- a/HelpSource/CodingDojo.schelp
+++ b/HelpSource/CodingDojo.schelp
@@ -56,6 +56,8 @@ argument:: username
 argument:: password
 argument:: serveraddress
 argument:: serverport
+argument:: groupName
+argument:: groupPassword
 
 
 INSTANCEMETHODS::


### PR DESCRIPTION
- this allows you to set up different rooms/groups instead of being
  stuck with the default of 'oscrouter'.
- (resolves issue #1)