### PR TITLE
made StartupFile optional in setup_files

### DIFF
--- a/examples/hyperfolder/setup_files/1a_Butz.scd
+++ b/examples/hyperfolder/setup_files/1a_Butz.scd
@@ -19,7 +19,7 @@ Butz.w.layout.spacing_(2);
 {
 	var startupClass = \StartupFile.asClass;
 startupClass.notNil.if{
-	Butz.add('StartupFile', { startupClass.choose });
+	Butz.add('StartupFile', { startupClass.dialog });
 };
 }.value;
 Butz.add('hyperfolder', { q.hyperfolder.openOS });

--- a/examples/hyperfolder/setup_files/1a_Butz.scd
+++ b/examples/hyperfolder/setup_files/1a_Butz.scd
@@ -13,8 +13,15 @@ Butz.w.layout.spacing_(2);
 ///// put more complex actions in as MFdef(name) or WinBounds.showOrMake(name);
 ///// and fill those functions later.
 
+
+
 // utility buttons for osc router visuals in system browser:
-Butz.add('StartupFile', { StartupFile.choose });
+{
+	var startupClass = \StartupFile.asClass;
+startupClass.notNil.if{
+	Butz.add('StartupFile', { startupClass.choose });
+};
+}.value;
 Butz.add('hyperfolder', { q.hyperfolder.openOS });
 
 Butz.add(\postPeers, {


### PR DESCRIPTION
The description says that the StartupFile quark is optional, however, it is required in the example setup.
The resulting error is hard to track down.

Two solutions:

1. require StartupFile Quark — adds another dependency, I vote against this
2. make StartupFile optional in example setup.

I implemented the latter.